### PR TITLE
fix: deprecation warning on time unit

### DIFF
--- a/lib/tesla_metadata_logger.ex
+++ b/lib/tesla_metadata_logger.ex
@@ -74,7 +74,7 @@ defmodule TeslaMetadataLogger do
   # from Plug.RequestId
   defp generate_request_id do
     binary = <<
-      System.system_time(:nanoseconds)::64,
+      System.system_time(:nanosecond)::64,
       :erlang.phash2({node(), self()}, 16_777_216)::24,
       :erlang.unique_integer()::32
     >>


### PR DESCRIPTION
We are getting this warning message in the logs

```
warning: deprecated time unit: :nanoseconds. A time unit should be :second, :millisecond, :microsecond, :nanosecond, or a positive integer
  (tesla_metadata_logger) lib/tesla_metadata_logger.ex:77: TeslaMetadataLogger.generate_request_id/0
  (tesla_metadata_logger) lib/tesla_metadata_logger.ex:13: TeslaMetadataLogger.call/3
```